### PR TITLE
Amend yamllint, environment setup

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -23,12 +23,6 @@ rules:
     max-spaces-before: 0
     min-spaces-after: 1
     max-spaces-after: 1
-  comments:
-    level: error
-    require-starting-space: true
-    min-spaces-from-content: 2
-  comments-indentation:
-    level: error
   document-end:
     level: error
     present: true

--- a/.yamllint
+++ b/.yamllint
@@ -1,47 +1,71 @@
-extends: default
-
-# Disable all cosmetic rules
-# (see https://github.com/ansible/ansible/pull/15470#issuecomment-214437876)
-# Only keep 'key-duplicates' and 'new-lines: {type: unix}' checks enabled.
-
+---
 rules:
   braces:
-    min-spaces-inside: 0
-    max-spaces-inside: 0
+    level: error
+    min-spaces-inside: 1
+    max-spaces-inside: 1
+    min-spaces-inside-empty: 0
+    max-spaces-inside-empty: 0
   brackets:
-    min-spaces-inside: 0
-    max-spaces-inside: 0
+    level: error
+    min-spaces-inside: 1
+    max-spaces-inside: 1
+    min-spaces-inside-empty: 0
+    max-spaces-inside-empty: 0
   colons:
+    level: error
     max-spaces-before: 0
     max-spaces-after: 1
   commas:
+    level: error
     max-spaces-before: 0
     min-spaces-after: 1
     max-spaces-after: 1
   comments:
-    level: warning
-    require-starting-space: no
-  comments-indentation: disable
-  document-start:
-    level: warning
-    present: yes
+    level: error
+    require-starting-space: true
+    min-spaces-from-content: 2
+  comments-indentation:
+    level: error
   document-end:
-    level: warning
-    present: yes
+    level: error
+    present: true
+  document-start:
+    level: error
+    present: true
   empty-lines:
+    level: error
     max: 2
     max-start: 0
     max-end: 0
+  empty-values:
+    level: error
+    forbid-in-block-mappings: true
+    forbid-in-flow-mappings: true
   hyphens:
+    level: error
     max-spaces-after: 1
   indentation:
-    spaces: consistent
-    indent-sequences: yes
-    check-multi-line-strings: no
+    level: error
+    spaces: 2
+    indent-sequences: true
+    check-multi-line-strings: false
   key-duplicates: enable
-  line-length: disable
+  key-ordering: disable
+  line-length:
+    level: error
+    max: 120
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: false
   new-line-at-end-of-file: enable
-  new-lines: {type: unix}
+  new-lines:
+    level: error
+    type: unix
+  octal-values:
+    level: error
+    forbid-implicit-octal: false
+    forbid-explicit-octal: false
   trailing-spaces: enable
   truthy:
-    level: warning
+    level: error
+...

--- a/.yamllint
+++ b/.yamllint
@@ -1,4 +1,6 @@
 ---
+ignore:
+  env/**/*
 rules:
   braces:
     level: error

--- a/README.md
+++ b/README.md
@@ -30,12 +30,15 @@ It is **recommended** to:
 
 > Use the following instructions to setup your testing environment
 > (make sure virtualenv2 is installed)
-> ```sh
+>
+```sh
 virtualenv2 env && source env/bin/activate
 pip install yamllint ansible-lint
 # Run tests run before each commit
+export HOOK=".git/hooks/prepare-commit-msg"
+if [ ! -f "$HOOK" ] ; then echo "#\!/bin/sh" > "$HOOK" && chmod +x "$HOOK"; fi
 cat << \EOF >> .git/hooks/prepare-commit-msg
-cmds=("ansible-lint ." "yamllint -c .yamllint .")
+cmds=("ansible-lint . -x ANSIBLE0016" "yamllint -c .yamllint .")
 for cmd in "${cmds[@]}"; do
   echo "Running ${cmd%% *}"
   cmd_out="$($cmd)"

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ git remote -v
 git remote set-url origin git@github.com:open-io/ansible-role-openio-ROLENAME.git
 
 vi meta/main.yml # change purpose and tags
-vi README.md 
+vi README.md
 git worktree add docker-tests origin/docker-tests
 ```
 
-You have to :
+It is **required** to:
   - Change the author
   - Choose one or many maintainers
   - Change the purpose
@@ -22,9 +22,31 @@ You have to :
   - Inform the responsibilities of this role (README)
   - Feed the `Role Variables` table (README)
   - Add one or more examples of playbook (README)
-  - Schedule tests with in Travis CI
+  - Activate tests in Travis CI
   - Write functional tests in the branch `docker-tests`
 
+It is **recommended** to:
+  - Setup tests on your local machine (see below)
+
+> Use the following instructions to setup your testing environment
+> (make sure virtualenv2 is installed)
+> ```sh
+virtualenv2 env && source env/bin/activate
+pip install yamllint ansible-lint
+# Run tests run before each commit
+cat << \EOF >> .git/hooks/prepare-commit-msg
+cmds=("ansible-lint ." "yamllint -c .yamllint .")
+for cmd in "${cmds[@]}"; do
+  echo "Running ${cmd%% *}"
+  cmd_out="$($cmd)"
+  echo -n "${cmd_out}"
+  if [ "$cmd_out" ]; then
+      echo -e "\nRejecting commit: ${cmd%% *} returned errors"
+      exit 1
+  fi
+done
+EOF
+```
 
 #### `Role Variables` table
 ```sh


### PR DESCRIPTION
Yaml lint amendments:
- all warnings set to errors (for Travis)
- braces/brackets/comments spaces consistent with flake8 equivalents
- enforce 2 space indent (according to YAML standards)
- 120 character lines to avoid endless oneliners
