### PR TITLE
Setup a second network when running container

### DIFF
--- a/docker-tests.sh
+++ b/docker-tests.sh
@@ -111,6 +111,9 @@ start_container() {
     "${image_tag}" \
     "${init}" \
     > "${container_id}"
+  # Create an additional network to perform tests on
+  docker network create net2 --driver bridge || true
+  docker network connect net2 $(cat ${container_id})
   set +x
 }
 


### PR DESCRIPTION
This allows to create a new network and assign an ip to the container.
By default, this network will have the subnet 172.18.0.0/16.

This allows to perform CI with multiple interfaces on nodes