### PR TITLE
Add commit template message to CONTRIB.md 

### DIFF
--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -1,18 +1,17 @@
-Contribution guide
----
+# Contribution guide
 
 Below are the guidelines to be followed for all PRs, as well as some explanation on why they are enforced.
 
-### 0. Scope
+## 0. Scope
 
 These guidelines are applicable, and must be followed for:
 
 - Any ansible role part of OpenIO SDS or related components (Monitoring, OIOFS....).
 - The official customer and community playbook repositories.
 
-### 1. Commit format
+## 1. Commit format
 
-```
+```text
 [TYPE]([SCOPE]): [TITLE]
 
  ##### SUMMARY
@@ -36,9 +35,9 @@ These guidelines are applicable, and must be followed for:
 | IMPACT          | if the change has an impact on previous versions that can break compatibility, explain it here. therwise, set to "N/A" | YES (N/A)   |
 | ADDITIONAL_INFO | Any additional informartion that doesn't belong in other fields                                                        | NO          |
 
-#### Example:
+### Example:
 
-```
+```text
 BUGFIX/MAJOR(component): Fix an issue
 
  ##### SUMMARY
@@ -54,25 +53,68 @@ N/A
 Aliquam in velit commodo, rutrum eros ut, condimentum nulla. Praesent tempus mi in nisi tempor posuere. Suspendisse in imperdiet justo
 ```
 
-### 2. Commits and pull requests
+### Configure Git Commit Message Template
+
+- Create a file at `~/.gitmessage-openio` (you can adapt the path if you want) with th following content:
+
+```text
+
+[TYPE]([SCOPE]): [TITLE]
+# TYPE 	CHANGE FEATURE BUGFIX/[SEVERITY] TEST REFACTOR TRIVIAL 	YES
+# SCOPE 	SDS OIOFS OIOFS_HA [COMPONENT] 	YES
+# SEVERITY 	MINOR MEDIUM MAJOR 	BUGFIX ONLY
+# COMPONENT 	only for roles: role name ; use the other values otherwise 	YES
+# TITLE 	commit title 	YES
+
+ ##### SUMMARY
+# SUMMARY 	describe what the commit does, why it is necessary, and how to use it 	YES
+
+
+ ##### IMPACT
+# IMPACT 	if the change has an impact on previous versions that can break compatibility, explain it here. therwise, set to "N/A" 	YES (N/A)
+
+
+ ##### ADDITIONAL INFORMATION
+# ADDITIONAL_INFO 	Any additional informartion that doesn't belong in other fields 	NO
+```
+
+- Edit the `~/.gitconfig` file (or the `.git/config` file of a repository if you want this setting only in this repository),
+  and add the directive `template = ~/.gitmessage-openio` (adapt the file path if you created it somewhere else) under the
+  `[commit]` section (or create the section if it does not already exist):
+ 
+ ```ini
+ # ...
+[commit]
+    template = ~/.gitmessage-openio
+ # ...
+ ```
+ 
+ - Stage a file and start a commit to use the newly installed commit message:
+ 
+ ```shell
+ git add -p . # stage some content
+ git commit # commit staged content and open a commit template message in the text editor configured with git
+ ```
+
+## 2. Commits and pull requests
 
 A pull request can have multiple commits. PR text is irrelevant long term, only the commit message matters. This allows to stay independant from GitHub, and simplifies the auto-generation of release information.
 
 Every commit should have one theme, described by the commit format. Additional commits related to the same theme on the same PR must be squashed into a single commit.
 
-### 3. Branches
+## 3. Branches
 
 It is highly recommended (although not enforced) to name each branch accordingly to the change made. E.g. a change that aims to fix an issue must be `fix-[issue_name]`. After the pull request is merged, the branch can be removed by the user.
 
-### 4. Tests
+## 4. Tests
 
 It is recommended when adding a new feature, to add tests corresponding to that particular feature in the docker-tests branch. This will help with the review of the PR in confirming the impact of the change.
 
-### 5. Git hook
+## 5. Git hook
 
 You can use the following githook:
 
-```
+```text
 #TITLE
 #CHANGE/FEATURE/BUGFIX/TEST/REFACTOR(SCOPE): Title
 #SCOPE: SDS / OIOFS / OIOFS_HA / role

--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -55,7 +55,7 @@ Aliquam in velit commodo, rutrum eros ut, condimentum nulla. Praesent tempus mi 
 
 ### Configure Git Commit Message Template
 
-- Create a file at `~/.gitmessage-openio` (you can adapt the path if you want) with th following content:
+- Create a file at `~/.gitmessage-openio` (you can adapt the path if you want) with the following content:
 
 ```text
 
@@ -71,7 +71,7 @@ Aliquam in velit commodo, rutrum eros ut, condimentum nulla. Praesent tempus mi 
 
 
  ##### IMPACT
-# IMPACT 	if the change has an impact on previous versions that can break compatibility, explain it here. therwise, set to "N/A" 	YES (N/A)
+# IMPACT 	if the change has an impact on previous versions that can break compatibility, explain it here. otherwise, set to "N/A" 	YES (N/A)
 
 
  ##### ADDITIONAL INFORMATION


### PR DESCRIPTION
This PR introduces the following changes:

- markdown linting the file
- Add a sub section explaining how to configure a commit message template